### PR TITLE
Permitir que o namespace SnackTech.API.Controllers tenha seus metodos visiveis para os testes unitarios

### DIFF
--- a/src/driving/SnackTech.API/Controllers/CustomBaseController.cs
+++ b/src/driving/SnackTech.API/Controllers/CustomBaseController.cs
@@ -1,7 +1,9 @@
 using Microsoft.AspNetCore.Mvc;
 using SnackTech.API.CustomResponses;
 using SnackTech.Application.Common;
+using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("SnackTech.API.Tests")]
 namespace SnackTech.API.Controllers
 {
     public abstract class CustomBaseController(ILogger logger) : ControllerBase


### PR DESCRIPTION
Permitir que o namespace SnackTech.API.Controllers tenha seus metodos internal visiveis para os testes