### PR TITLE
reorganizando código entre projetos para estar de acordo

### DIFF
--- a/src/core/SnackTech.Application/ModuleInjectionDependency.cs
+++ b/src/core/SnackTech.Application/ModuleInjectionDependency.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
-using SnackTech.Application.Interfaces;
 using SnackTech.Application.UseCases;
+using SnackTech.Domain.Ports.Driven;
 
 namespace SnackTech.Application
 {

--- a/src/core/SnackTech.Application/UseCases/BaseService.cs
+++ b/src/core/SnackTech.Application/UseCases/BaseService.cs
@@ -1,5 +1,5 @@
 using Microsoft.Extensions.Logging;
-using SnackTech.Application.Common;
+using SnackTech.Domain.Common;
 
 namespace SnackTech.Application.UseCases
 {

--- a/src/core/SnackTech.Application/UseCases/ClienteService.cs
+++ b/src/core/SnackTech.Application/UseCases/ClienteService.cs
@@ -1,10 +1,10 @@
 using Microsoft.Extensions.Logging;
-using SnackTech.Application.Common;
-using SnackTech.Application.DTOs.Cliente;
-using SnackTech.Application.Interfaces;
-using SnackTech.Domain.Contracts;
+using SnackTech.Domain.Common;
+using SnackTech.Domain.DTOs.Cliente;
 using SnackTech.Domain.Guards;
 using SnackTech.Domain.Models;
+using SnackTech.Domain.Ports.Driven;
+using SnackTech.Domain.Ports.Driving;
 
 namespace SnackTech.Application.UseCases
 {

--- a/src/core/SnackTech.Application/UseCases/PedidoService.cs
+++ b/src/core/SnackTech.Application/UseCases/PedidoService.cs
@@ -1,10 +1,10 @@
 using Microsoft.Extensions.Logging;
-using SnackTech.Application.Common;
-using SnackTech.Application.DTOs.Pedido;
-using SnackTech.Application.Interfaces;
-using SnackTech.Domain.Contracts;
+using SnackTech.Domain.Common;
+using SnackTech.Domain.DTOs.Pedido;
 using SnackTech.Domain.Guards;
 using SnackTech.Domain.Models;
+using SnackTech.Domain.Ports.Driven;
+using SnackTech.Domain.Ports.Driving;
 
 namespace SnackTech.Application.UseCases
 {

--- a/src/core/SnackTech.Application/UseCases/ProdutoService.cs
+++ b/src/core/SnackTech.Application/UseCases/ProdutoService.cs
@@ -1,10 +1,10 @@
 using Microsoft.Extensions.Logging;
-using SnackTech.Application.Common;
-using SnackTech.Application.DTOs.Produto;
-using SnackTech.Application.Interfaces;
-using SnackTech.Domain.Contracts;
+using SnackTech.Domain.Common;
+using SnackTech.Domain.DTOs.Produto;
 using SnackTech.Domain.Guards;
 using SnackTech.Domain.Models;
+using SnackTech.Domain.Ports.Driven;
+using SnackTech.Domain.Ports.Driving;
 
 namespace SnackTech.Application.UseCases
 {

--- a/src/core/SnackTech.Domain/Common/Result.cs
+++ b/src/core/SnackTech.Domain/Common/Result.cs
@@ -1,4 +1,4 @@
-namespace SnackTech.Application.Common
+namespace SnackTech.Domain.Common
 {
     public class Result
     {

--- a/src/core/SnackTech.Domain/DTOs/Cliente/CadastroCliente.cs
+++ b/src/core/SnackTech.Domain/DTOs/Cliente/CadastroCliente.cs
@@ -1,5 +1,5 @@
 
-namespace SnackTech.Application.DTOs.Cliente
+namespace SnackTech.Domain.DTOs.Cliente
 {
     public class CadastroCliente
     {

--- a/src/core/SnackTech.Domain/DTOs/Cliente/RetornoCliente.cs
+++ b/src/core/SnackTech.Domain/DTOs/Cliente/RetornoCliente.cs
@@ -1,6 +1,6 @@
 using DomainModels = SnackTech.Domain.Models;
 
-namespace SnackTech.Application.DTOs.Cliente
+namespace SnackTech.Domain.DTOs.Cliente
 {
     public class RetornoCliente
     {

--- a/src/core/SnackTech.Domain/DTOs/Pedido/AtualizacaoPedido.cs
+++ b/src/core/SnackTech.Domain/DTOs/Pedido/AtualizacaoPedido.cs
@@ -1,4 +1,4 @@
-namespace SnackTech.Application.DTOs.Pedido
+namespace SnackTech.Domain.DTOs.Pedido
 {
     public class AtualizacaoPedido
     {

--- a/src/core/SnackTech.Domain/DTOs/Pedido/RetornoPedido.cs
+++ b/src/core/SnackTech.Domain/DTOs/Pedido/RetornoPedido.cs
@@ -1,6 +1,6 @@
 using DomainModels = SnackTech.Domain.Models;
 
-namespace SnackTech.Application.DTOs.Pedido
+namespace SnackTech.Domain.DTOs.Pedido
 {
     public class RetornoPedido
     {

--- a/src/core/SnackTech.Domain/DTOs/Pedido/RetornoPedidoItem.cs
+++ b/src/core/SnackTech.Domain/DTOs/Pedido/RetornoPedidoItem.cs
@@ -1,6 +1,6 @@
 using SnackTech.Domain.Models;
 
-namespace SnackTech.Application.DTOs.Pedido
+namespace SnackTech.Domain.DTOs.Pedido
 {
     public class RetornoPedidoItem
     {

--- a/src/core/SnackTech.Domain/DTOs/Produto/EdicaoProduto.cs
+++ b/src/core/SnackTech.Domain/DTOs/Produto/EdicaoProduto.cs
@@ -1,11 +1,11 @@
 
-namespace SnackTech.Application.DTOs.Produto
+namespace SnackTech.Domain.DTOs.Produto
 {
-    public class NovoProduto
+    public class EdicaoProduto
     {
         public int Categoria {get; set;}
         public string Nome {get; set;} = string.Empty;
         public string Descricao {get; set;} = string.Empty;
-        public decimal Valor {get; set;}
+        public decimal Valor {get; set;}        
     }
 }

--- a/src/core/SnackTech.Domain/DTOs/Produto/NovoProduto.cs
+++ b/src/core/SnackTech.Domain/DTOs/Produto/NovoProduto.cs
@@ -1,11 +1,11 @@
 
-namespace SnackTech.Application.DTOs.Produto
+namespace SnackTech.Domain.DTOs.Produto
 {
-    public class EdicaoProduto
+    public class NovoProduto
     {
         public int Categoria {get; set;}
         public string Nome {get; set;} = string.Empty;
         public string Descricao {get; set;} = string.Empty;
-        public decimal Valor {get; set;}        
+        public decimal Valor {get; set;}
     }
 }

--- a/src/core/SnackTech.Domain/DTOs/Produto/RetornoProduto.cs
+++ b/src/core/SnackTech.Domain/DTOs/Produto/RetornoProduto.cs
@@ -1,6 +1,6 @@
 using DomainModels = SnackTech.Domain.Models;
 
-namespace SnackTech.Application.DTOs.Produto
+namespace SnackTech.Domain.DTOs.Produto
 {
     public class RetornoProduto
     {

--- a/src/core/SnackTech.Domain/Models/Pedido.cs
+++ b/src/core/SnackTech.Domain/Models/Pedido.cs
@@ -7,7 +7,7 @@ namespace SnackTech.Domain.Models
     public class Pedido
     {
         private decimal _valor;
-        private readonly List<PedidoItem> _itens = new();
+        private readonly List<PedidoItem> _itens = [];
 
         public Guid Id { get; private set; }
         public DateTime DataCriacao { get; private set; }

--- a/src/core/SnackTech.Domain/Ports/Driven/IClienteService.cs
+++ b/src/core/SnackTech.Domain/Ports/Driven/IClienteService.cs
@@ -1,7 +1,7 @@
-using SnackTech.Application.Common;
-using SnackTech.Application.DTOs.Cliente;
+using SnackTech.Domain.Common;
+using SnackTech.Domain.DTOs.Cliente;
 
-namespace SnackTech.Application.Interfaces
+namespace SnackTech.Domain.Ports.Driven
 {
     public interface IClienteService
     {

--- a/src/core/SnackTech.Domain/Ports/Driven/IPedidoService.cs
+++ b/src/core/SnackTech.Domain/Ports/Driven/IPedidoService.cs
@@ -1,7 +1,7 @@
-using SnackTech.Application.Common;
-using SnackTech.Application.DTOs.Pedido;
+using SnackTech.Domain.Common;
+using SnackTech.Domain.DTOs.Pedido;
 
-namespace SnackTech.Application.Interfaces
+namespace SnackTech.Domain.Ports.Driven
 {
     public interface IPedidoService
     {

--- a/src/core/SnackTech.Domain/Ports/Driven/IProdutoService.cs
+++ b/src/core/SnackTech.Domain/Ports/Driven/IProdutoService.cs
@@ -1,7 +1,7 @@
-using SnackTech.Application.Common;
-using SnackTech.Application.DTOs.Produto;
+using SnackTech.Domain.Common;
+using SnackTech.Domain.DTOs.Produto;
 
-namespace SnackTech.Application.Interfaces
+namespace SnackTech.Domain.Ports.Driven
 {
     public interface IProdutoService
     {

--- a/src/core/SnackTech.Domain/Ports/Driving/IClienteRepository.cs
+++ b/src/core/SnackTech.Domain/Ports/Driving/IClienteRepository.cs
@@ -1,6 +1,6 @@
 using SnackTech.Domain.Models;
 
-namespace SnackTech.Domain.Contracts
+namespace SnackTech.Domain.Ports.Driving
 {
     public interface IClienteRepository
     {

--- a/src/core/SnackTech.Domain/Ports/Driving/IPedidoRepository.cs
+++ b/src/core/SnackTech.Domain/Ports/Driving/IPedidoRepository.cs
@@ -1,12 +1,12 @@
 using SnackTech.Domain.Models;
 
-namespace SnackTech.Domain.Contracts
+namespace SnackTech.Domain.Ports.Driving
 {
     public interface IPedidoRepository
     {
         Task InserirPedidoAsync(Pedido novoPedido);
-        //TODO: Separar método AtualizarPedido em dois, um para atualizar apenas o pedido em si, e outro para atualizar apenas os itens do pedido.
-        //Pois da forma como está, atualizaremos toda a entidade de Pedido quando apenas queremos atualizar os itens do pedido.
+        //TODO: Separar mï¿½todo AtualizarPedido em dois, um para atualizar apenas o pedido em si, e outro para atualizar apenas os itens do pedido.
+        //Pois da forma como estï¿½, atualizaremos toda a entidade de Pedido quando apenas queremos atualizar os itens do pedido.
         Task AtualizarPedidoAsync(Pedido pedidoAtualizado);
         Task<IEnumerable<Pedido>> PesquisarPedidosParaPagamentoAsync();
         Task<Pedido?> PesquisarPorIdentificacaoAsync(Guid identificacao);

--- a/src/core/SnackTech.Domain/Ports/Driving/IProdutoRepository.cs
+++ b/src/core/SnackTech.Domain/Ports/Driving/IProdutoRepository.cs
@@ -1,7 +1,7 @@
 using SnackTech.Domain.Enums;
 using SnackTech.Domain.Models;
 
-namespace SnackTech.Domain.Contracts
+namespace SnackTech.Domain.Ports.Driving
 {
     public interface IProdutoRepository
     {

--- a/src/driven/SnackTech.Adapter.DataBase/Configurations/ClienteConfiguration.cs
+++ b/src/driven/SnackTech.Adapter.DataBase/Configurations/ClienteConfiguration.cs
@@ -1,9 +1,11 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using SnackTech.Domain.Models;
 
 namespace SnackTech.Adapter.DataBase.Configurations
 {
+    [ExcludeFromCodeCoverage]
     internal sealed class ClienteConfiguration : IEntityTypeConfiguration<Cliente>
     {
         public void Configure(EntityTypeBuilder<Cliente> builder)

--- a/src/driven/SnackTech.Adapter.DataBase/Configurations/PedidoConfiguration.cs
+++ b/src/driven/SnackTech.Adapter.DataBase/Configurations/PedidoConfiguration.cs
@@ -1,9 +1,11 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using SnackTech.Domain.Models;
 
 namespace SnackTech.Adapter.DataBase.Configurations
 {
+    [ExcludeFromCodeCoverage]
     internal sealed class PedidoConfiguration : IEntityTypeConfiguration<Pedido>
     {
         public void Configure(EntityTypeBuilder<Pedido> builder)

--- a/src/driven/SnackTech.Adapter.DataBase/Configurations/PedidoItemConfiguration.cs
+++ b/src/driven/SnackTech.Adapter.DataBase/Configurations/PedidoItemConfiguration.cs
@@ -1,9 +1,11 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using SnackTech.Domain.Models;
 
 namespace SnackTech.Adapter.DataBase.Configurations
 {
+    [ExcludeFromCodeCoverage]
     internal sealed class PedidoItemConfiguration : IEntityTypeConfiguration<PedidoItem>
     {
         public void Configure(EntityTypeBuilder<PedidoItem> builder)

--- a/src/driven/SnackTech.Adapter.DataBase/Configurations/PessoaConfiguration.cs
+++ b/src/driven/SnackTech.Adapter.DataBase/Configurations/PessoaConfiguration.cs
@@ -1,9 +1,11 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using SnackTech.Domain.Models;
 
 namespace SnackTech.Adapter.DataBase.Configurations
 {
+    [ExcludeFromCodeCoverage]
     internal sealed class PessoaConfiguration : IEntityTypeConfiguration<Pessoa>
     {
         public void Configure(EntityTypeBuilder<Pessoa> builder)

--- a/src/driven/SnackTech.Adapter.DataBase/Configurations/ProdutoConfiguration.cs
+++ b/src/driven/SnackTech.Adapter.DataBase/Configurations/ProdutoConfiguration.cs
@@ -1,9 +1,11 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using SnackTech.Domain.Models;
 
 namespace SnackTech.Adapter.DataBase.Configurations
 {
+    [ExcludeFromCodeCoverage]
     internal sealed class ProdutoConfiguration : IEntityTypeConfiguration<Produto>
     {
         public void Configure(EntityTypeBuilder<Produto> builder)

--- a/src/driven/SnackTech.Adapter.DataBase/Context/RepositoryDbContext.cs
+++ b/src/driven/SnackTech.Adapter.DataBase/Context/RepositoryDbContext.cs
@@ -1,8 +1,10 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore;
 using SnackTech.Domain.Models;
 
 namespace SnackTech.Adapter.DataBase.Context
 {
+    [ExcludeFromCodeCoverage]
     public class RepositoryDbContext(DbContextOptions options) : DbContext(options)
     {
         public DbSet<Cliente> Clientes { get; set; }

--- a/src/driven/SnackTech.Adapter.DataBase/Context/RepositoryDbContextFactory.cs
+++ b/src/driven/SnackTech.Adapter.DataBase/Context/RepositoryDbContextFactory.cs
@@ -1,11 +1,13 @@
 ﻿using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SnackTech.Adapter.DataBase.Context
 {
     /// <summary>
     /// For local use only
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class RepositoryDbContextFactory : IDesignTimeDbContextFactory<RepositoryDbContext>
     {
         public RepositoryDbContext CreateDbContext(string[] args)

--- a/src/driven/SnackTech.Adapter.DataBase/Migrations/20240725113948_FirstCreation.Designer.cs
+++ b/src/driven/SnackTech.Adapter.DataBase/Migrations/20240725113948_FirstCreation.Designer.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SnackTech.Adapter.DataBase.Context;
+using System.Diagnostics.CodeAnalysis;
 
 #nullable disable
 

--- a/src/driven/SnackTech.Adapter.DataBase/Migrations/20240725113948_FirstCreation.cs
+++ b/src/driven/SnackTech.Adapter.DataBase/Migrations/20240725113948_FirstCreation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
@@ -6,6 +7,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace SnackTech.Adapter.DataBase.Migrations
 {
     /// <inheritdoc />
+    [ExcludeFromCodeCoverage]
     public partial class FirstCreation : Migration
     {
         /// <inheritdoc />

--- a/src/driven/SnackTech.Adapter.DataBase/Migrations/20240729114323_CreateClientePadrao.Designer.cs
+++ b/src/driven/SnackTech.Adapter.DataBase/Migrations/20240729114323_CreateClientePadrao.Designer.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SnackTech.Adapter.DataBase.Context;
+using System.Diagnostics.CodeAnalysis;
 
 #nullable disable
 

--- a/src/driven/SnackTech.Adapter.DataBase/Migrations/20240729114323_CreateClientePadrao.cs
+++ b/src/driven/SnackTech.Adapter.DataBase/Migrations/20240729114323_CreateClientePadrao.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
 namespace SnackTech.Adapter.DataBase.Migrations
 {
+    [ExcludeFromCodeCoverage]
     /// <inheritdoc />
     public partial class CreateClientePadrao : Migration
     {

--- a/src/driven/SnackTech.Adapter.DataBase/Migrations/RepositoryDbContextModelSnapshot.cs
+++ b/src/driven/SnackTech.Adapter.DataBase/Migrations/RepositoryDbContextModelSnapshot.cs
@@ -5,12 +5,15 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SnackTech.Adapter.DataBase.Context;
+using Microsoft.EntityFrameworkCore.Migrations;
+using System.Diagnostics.CodeAnalysis;
 
 #nullable disable
 
 namespace SnackTech.Adapter.DataBase.Migrations
 {
     [DbContext(typeof(RepositoryDbContext))]
+    [ExcludeFromCodeCoverage]
     partial class RepositoryDbContextModelSnapshot : ModelSnapshot
     {
         protected override void BuildModel(ModelBuilder modelBuilder)

--- a/src/driven/SnackTech.Adapter.DataBase/ModuleInjectionDependency.cs
+++ b/src/driven/SnackTech.Adapter.DataBase/ModuleInjectionDependency.cs
@@ -1,7 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using SnackTech.Adapter.DataBase.Repositories;
-using SnackTech.Domain.Contracts;
+using SnackTech.Domain.Ports.Driving;
 
 namespace SnackTech.Adapter.DataBase
 {

--- a/src/driven/SnackTech.Adapter.DataBase/Repositories/ClienteRepository.cs
+++ b/src/driven/SnackTech.Adapter.DataBase/Repositories/ClienteRepository.cs
@@ -1,7 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using SnackTech.Adapter.DataBase.Context;
-using SnackTech.Domain.Contracts;
 using SnackTech.Domain.Models;
+using SnackTech.Domain.Ports.Driving;
 
 namespace SnackTech.Adapter.DataBase.Repositories
 {
@@ -17,7 +17,7 @@ namespace SnackTech.Adapter.DataBase.Repositories
 
         public async Task<Cliente> PesquisarClientePadraoAsync()
         {
-            //TODO: Encontrar uma melhor forma de definir o cliente padrão. Por hora, criamos um cliente com esse ID hard coded
+            //TODO: Encontrar uma melhor forma de definir o cliente padrï¿½o. Por hora, criamos um cliente com esse ID hard coded
             var idClientePadrao = "6ee54a46-007f-4e4c-9fe8-1a13eadf7fd1";
             var guid = Guid.Parse(idClientePadrao);
             return await _repositoryDbContext.Clientes

--- a/src/driven/SnackTech.Adapter.DataBase/Repositories/PedidoRepository.cs
+++ b/src/driven/SnackTech.Adapter.DataBase/Repositories/PedidoRepository.cs
@@ -1,8 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using SnackTech.Adapter.DataBase.Context;
-using SnackTech.Domain.Contracts;
 using SnackTech.Domain.Models;
+using SnackTech.Domain.Ports.Driving;
 
 namespace SnackTech.Adapter.DataBase.Repositories
 {

--- a/src/driven/SnackTech.Adapter.DataBase/Repositories/ProdutoRepository.cs
+++ b/src/driven/SnackTech.Adapter.DataBase/Repositories/ProdutoRepository.cs
@@ -1,8 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using SnackTech.Adapter.DataBase.Context;
-using SnackTech.Domain.Contracts;
 using SnackTech.Domain.Enums;
 using SnackTech.Domain.Models;
+using SnackTech.Domain.Ports.Driving;
 
 namespace SnackTech.Adapter.DataBase.Repositories
 {

--- a/src/driving/SnackTech.API/Controllers/ClientesController.cs
+++ b/src/driving/SnackTech.API/Controllers/ClientesController.cs
@@ -1,8 +1,8 @@
 using System.Net.Mime;
 using Microsoft.AspNetCore.Mvc;
 using SnackTech.API.CustomResponses;
-using SnackTech.Application.DTOs.Cliente;
-using SnackTech.Application.Interfaces;
+using SnackTech.Domain.DTOs.Cliente;
+using SnackTech.Domain.Ports.Driven;
 
 namespace SnackTech.API.Controllers
 {

--- a/src/driving/SnackTech.API/Controllers/CustomBaseController.cs
+++ b/src/driving/SnackTech.API/Controllers/CustomBaseController.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using SnackTech.API.CustomResponses;
-using SnackTech.Application.Common;
+using SnackTech.Domain.Common;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("SnackTech.API.Tests")]

--- a/src/driving/SnackTech.API/Controllers/PedidosController.cs
+++ b/src/driving/SnackTech.API/Controllers/PedidosController.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using SnackTech.API.CustomResponses;
-using SnackTech.Application.DTOs.Pedido;
-using SnackTech.Application.Interfaces;
+using SnackTech.Domain.DTOs.Pedido;
+using SnackTech.Domain.Ports.Driven;
 using System.Net.Mime;
 
 namespace SnackTech.API.Controllers

--- a/src/driving/SnackTech.API/Controllers/ProdutosController.cs
+++ b/src/driving/SnackTech.API/Controllers/ProdutosController.cs
@@ -1,8 +1,8 @@
 using System.Net.Mime;
 using Microsoft.AspNetCore.Mvc;
 using SnackTech.API.CustomResponses;
-using SnackTech.Application.DTOs.Produto;
-using SnackTech.Application.Interfaces;
+using SnackTech.Domain.DTOs.Produto;
+using SnackTech.Domain.Ports.Driven;
 
 namespace SnackTech.API.Controllers
 {

--- a/src/tests/SnackTech.API.Tests/ControllersTests/ClientesControllerTests.cs
+++ b/src/tests/SnackTech.API.Tests/ControllersTests/ClientesControllerTests.cs
@@ -3,9 +3,9 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using SnackTech.API.Controllers;
 using SnackTech.API.CustomResponses;
-using SnackTech.Application.Common;
-using SnackTech.Application.DTOs.Cliente;
-using SnackTech.Application.Interfaces;
+using SnackTech.Domain.Common;
+using SnackTech.Domain.DTOs.Cliente;
+using SnackTech.Domain.Ports.Driven;
 
 namespace SnackTech.API.Tests.ControllersTests
 {

--- a/src/tests/SnackTech.API.Tests/ControllersTests/CustomBaseControllerTests.cs
+++ b/src/tests/SnackTech.API.Tests/ControllersTests/CustomBaseControllerTests.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using SnackTech.API.Controllers;
 using SnackTech.API.CustomResponses;
-using SnackTech.Application.Common;
+using SnackTech.Domain.Common;
 
 namespace SnackTech.API.Tests.ControllersTests
 {

--- a/src/tests/SnackTech.API.Tests/ControllersTests/PedidosControllerTests.cs
+++ b/src/tests/SnackTech.API.Tests/ControllersTests/PedidosControllerTests.cs
@@ -3,13 +3,10 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using SnackTech.API.Controllers;
 using SnackTech.API.CustomResponses;
-using SnackTech.Application.Common;
-using SnackTech.Application.DTOs.Cliente;
-using SnackTech.Application.DTOs.Pedido;
-using SnackTech.Application.DTOs.Produto;
-using SnackTech.Application.Interfaces;
-using SnackTech.Application.UseCases;
-using Xunit.Abstractions;
+using SnackTech.Domain.Common;
+using SnackTech.Domain.DTOs.Cliente;
+using SnackTech.Domain.DTOs.Pedido;
+using SnackTech.Domain.Ports.Driven;
 
 namespace SnackTech.API.Tests.ControllersTests
 {

--- a/src/tests/SnackTech.API.Tests/ControllersTests/ProdutosControllerTests.cs
+++ b/src/tests/SnackTech.API.Tests/ControllersTests/ProdutosControllerTests.cs
@@ -3,9 +3,9 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using SnackTech.API.Controllers;
 using SnackTech.API.CustomResponses;
-using SnackTech.Application.Common;
-using SnackTech.Application.DTOs.Produto;
-using SnackTech.Application.Interfaces;
+using SnackTech.Domain.Common;
+using SnackTech.Domain.DTOs.Produto;
+using SnackTech.Domain.Ports.Driven;
 
 namespace SnackTech.API.Tests.ControllersTests
 {

--- a/src/tests/SnackTech.Application.Tests/CommonTests/ResultTests.cs
+++ b/src/tests/SnackTech.Application.Tests/CommonTests/ResultTests.cs
@@ -1,6 +1,6 @@
-using SnackTech.Application.Common;
+using SnackTech.Domain.Common;
 
-namespace SnackTech.Application.Tests.CommonTests
+namespace SnackTech.Domain.Tests.CommonTests
 {
     public class ResultTests
     {

--- a/src/tests/SnackTech.Application.Tests/UseCasesTests/BaseServiceTests.cs
+++ b/src/tests/SnackTech.Application.Tests/UseCasesTests/BaseServiceTests.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Moq;
-using SnackTech.Application.Common;
 using SnackTech.Application.UseCases;
+using SnackTech.Domain.Common;
 
 namespace SnackTech.Application.Tests.UseCasesTests
 {

--- a/src/tests/SnackTech.Application.Tests/UseCasesTests/ClienteServiceTests.cs
+++ b/src/tests/SnackTech.Application.Tests/UseCasesTests/ClienteServiceTests.cs
@@ -1,9 +1,9 @@
 using Microsoft.Extensions.Logging;
 using Moq;
-using SnackTech.Application.DTOs.Cliente;
 using SnackTech.Application.UseCases;
-using SnackTech.Domain.Contracts;
+using SnackTech.Domain.DTOs.Cliente;
 using SnackTech.Domain.Models;
+using SnackTech.Domain.Ports.Driving;
 
 namespace SnackTech.Application.Tests.UseCasesTests
 {

--- a/src/tests/SnackTech.Application.Tests/UseCasesTests/PedidoServiceTests.cs
+++ b/src/tests/SnackTech.Application.Tests/UseCasesTests/PedidoServiceTests.cs
@@ -1,10 +1,10 @@
 using Microsoft.Extensions.Logging;
 using Moq;
-using SnackTech.Application.DTOs.Pedido;
+using SnackTech.Domain.DTOs.Pedido;
 using SnackTech.Application.UseCases;
-using SnackTech.Domain.Contracts;
 using SnackTech.Domain.Enums;
 using SnackTech.Domain.Models;
+using SnackTech.Domain.Ports.Driving;
 
 namespace SnackTech.Application.Tests.UseCasesTests
 {

--- a/src/tests/SnackTech.Application.Tests/UseCasesTests/ProdutoServiceTests.cs
+++ b/src/tests/SnackTech.Application.Tests/UseCasesTests/ProdutoServiceTests.cs
@@ -1,10 +1,10 @@
 using Microsoft.Extensions.Logging;
 using Moq;
-using SnackTech.Application.DTOs.Produto;
+using SnackTech.Domain.DTOs.Produto;
 using SnackTech.Application.UseCases;
-using SnackTech.Domain.Contracts;
 using SnackTech.Domain.Enums;
 using SnackTech.Domain.Models;
+using SnackTech.Domain.Ports.Driving;
 
 namespace SnackTech.Application.Tests.UseCasesTests
 {


### PR DESCRIPTION
Reorganizando código entre projetos para estar de acordo com a arquitetura hexagonal.

DTOs, Common e Interfaces dentro de Application foram movidas para Domain/Ports/Driving.
Contracts no Domain foi movido para Ports/Driven.

Referências atualizadas nos projetos de API, Adapter.Database, Application e nos projetos de Testes.

Garantia de testes unitários executando corretamente.

Exclusão da cobertura de arquivos específicos ao EF (Context, Configurations, Migrations)