### PR TITLE
Acertando alguns pontos de melhora

### DIFF
--- a/src/core/SnackTech.Application/UseCases/ClienteService.cs
+++ b/src/core/SnackTech.Application/UseCases/ClienteService.cs
@@ -16,6 +16,12 @@ namespace SnackTech.Application.UseCases
         {
             async Task<Result<RetornoCliente>> processo(){
                 var novoCliente = new Cliente(cadastroCliente.Nome,cadastroCliente.Email,cadastroCliente.CPF);
+                var clienteDto = await clienteRepository.PesquisarPorCpfAsync(novoCliente.Cpf);
+                
+                if(clienteDto is not null){
+                    return new Result<RetornoCliente>($"{novoCliente.Cpf} já foi cadastrado.",true);
+                }
+                
                 await clienteRepository.InserirClienteAsync((Domain.DTOs.Driven.ClienteDto)novoCliente);
                 var retorno = RetornoCliente.APartirDeCliente(novoCliente);
                 return new Result<RetornoCliente>(retorno);
@@ -39,12 +45,12 @@ namespace SnackTech.Application.UseCases
             return await CommonExecution($"ClienteService.IdentificarPorCpf - {cpf}",processo);
         }
 
-        public async Task<Result<Guid>> SelecionarClientePadrao()
+        public async Task<Result<RetornoCliente>> SelecionarClientePadrao()
         {
-            async Task<Result<Guid>> processo(){
+            async Task<Result<RetornoCliente>> processo(){
                 var clientePadrao = await clienteRepository.PesquisarClientePadraoAsync();
-                var retorno = clientePadrao.Id;
-                return new Result<Guid>(retorno);
+                var retorno = RetornoCliente.APartirDeCliente((Cliente)clientePadrao);
+                return new Result<RetornoCliente>(retorno);
             }
             return await CommonExecution("ClienteService.SelecionarClientePadrao",processo);
         }

--- a/src/core/SnackTech.Domain/DTOs/Driving/Pedido/IniciarPedido.cs
+++ b/src/core/SnackTech.Domain/DTOs/Driving/Pedido/IniciarPedido.cs
@@ -1,0 +1,8 @@
+
+namespace SnackTech.Domain.DTOs.Driving.Pedido
+{
+    public class IniciarPedido
+    {
+         public string Cpf {get; set;} = string.Empty;        
+    }
+}

--- a/src/core/SnackTech.Domain/Ports/Driving/IClienteService.cs
+++ b/src/core/SnackTech.Domain/Ports/Driving/IClienteService.cs
@@ -7,6 +7,6 @@ namespace SnackTech.Domain.Ports.Driving
     {
         Task<Result<RetornoCliente>> Cadastrar(CadastroCliente cadastroCliente);
         Task<Result<RetornoCliente>> IdentificarPorCpf(string cpf);
-        Task<Result<Guid>> SelecionarClientePadrao();
+        Task<Result<RetornoCliente>> SelecionarClientePadrao();
     }
 }

--- a/src/driving/SnackTech.API/Controllers/ClientesController.cs
+++ b/src/driving/SnackTech.API/Controllers/ClientesController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc;
 using SnackTech.API.CustomResponses;
 using SnackTech.Domain.DTOs.Driving.Cliente;
 using SnackTech.Domain.Ports.Driving;
-using SnackTech.Domain.Ports.Driven;
 using Swashbuckle.AspNetCore.Annotations;
 
 namespace SnackTech.API.Controllers

--- a/src/driving/SnackTech.API/Controllers/PedidosController.cs
+++ b/src/driving/SnackTech.API/Controllers/PedidosController.cs
@@ -18,30 +18,30 @@ namespace SnackTech.API.Controllers
         [ProducesResponseType<Guid>(StatusCodes.Status200OK)]
         [ProducesResponseType<ErrorResponse>(StatusCodes.Status400BadRequest)]
         [ProducesResponseType<ErrorResponse>(StatusCodes.Status500InternalServerError)]
-        [Route("iniciar")]
+        [Route("")]
         [SwaggerOperation(Summary = "Inicia um novo pedido a partir do CPF de um cliente previamente cadastrado no banco. Informe null para iniciar um novo pedido do cliente padrão")]
         [SwaggerResponse(StatusCodes.Status200OK, "Retorna o identificador do novo pedido", typeof(Guid))]
-        public async Task<IActionResult> IniciarPedido([FromBody] string cpfCliente)
-            => await CommonExecution("Pedidos.IniciarPedido", pedidoService.IniciarPedido(cpfCliente));
+        public async Task<IActionResult> IniciarPedido([FromBody] IniciarPedido pedidoIniciado)
+            => await CommonExecution("Pedidos.IniciarPedido", pedidoService.IniciarPedido(pedidoIniciado.Cpf));
 
-        [HttpPost]
+        [HttpPut]
         [Consumes(MediaTypeNames.Application.Json)]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType<ErrorResponse>(StatusCodes.Status400BadRequest)]
         [ProducesResponseType<ErrorResponse>(StatusCodes.Status500InternalServerError)]
-        [Route("atualizar")]
+        [Route("")]
         [SwaggerOperation(Summary = "Atualiza o pedido (itens anexos) que ainda não esteja no status aguardando pagamento")]
         public async Task<IActionResult> AtualizarPedido([FromBody] AtualizacaoPedido atualizacaoPedido)
             => await CommonExecution("Pedidos.AtualizarPedido", pedidoService.AtualizarPedido(atualizacaoPedido));
 
-        [HttpPost]
+        [HttpPatch]
         [Consumes(MediaTypeNames.Application.Json)]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType<ErrorResponse>(StatusCodes.Status400BadRequest)]
         [ProducesResponseType<ErrorResponse>(StatusCodes.Status500InternalServerError)]
-        [Route("finalizar-para-pagamento")]
+        [Route("finalizar-para-pagamento/{identificacao:guid}")]
         [SwaggerOperation(Summary = "Finaliza o pedido com o identificador informado e o coloca na situação de aguardando pagamento")]
-        public async Task<IActionResult> FinalizarPedidoParaPagamento([FromBody] string identificacao)
+        public async Task<IActionResult> FinalizarPedidoParaPagamento([FromRoute] string identificacao)
             => await CommonExecution("Pedidos.FinalizarPedidoParaPagamento", pedidoService.FinalizarPedidoParaPagamento(identificacao));
 
         [HttpGet]
@@ -66,9 +66,9 @@ namespace SnackTech.API.Controllers
         [ProducesResponseType<RetornoPedido>(StatusCodes.Status200OK)]
         [ProducesResponseType<ErrorResponse>(StatusCodes.Status400BadRequest)]
         [ProducesResponseType<ErrorResponse>(StatusCodes.Status500InternalServerError)]
-        [Route("ultimo-pedido-cliente")]
+        [Route("ultimo-pedido-cliente/{cpfCliente}")]
         [SwaggerOperation(Summary = "Retorna o pedido mais recente do cliente com CPF informado. Não é permitida a consulta do último pedido do cliente padrão")]
-        public async Task<IActionResult> BuscarUltimoPedidoCliente([FromQuery] string cpfCliente)
+        public async Task<IActionResult> BuscarUltimoPedidoCliente([FromRoute] string cpfCliente)
             => await CommonExecution("Pedidos.ListarPedidosParaPagamento", pedidoService.BuscarUltimoPedidoCliente(cpfCliente));
     }
 }

--- a/src/driving/SnackTech.API/Controllers/PedidosController.cs
+++ b/src/driving/SnackTech.API/Controllers/PedidosController.cs
@@ -2,7 +2,6 @@ using Microsoft.AspNetCore.Mvc;
 using SnackTech.API.CustomResponses;
 using SnackTech.Domain.DTOs.Driving.Pedido;
 using SnackTech.Domain.Ports.Driving;
-using SnackTech.Domain.Ports.Driven;
 using Swashbuckle.AspNetCore.Annotations;
 using System.Net.Mime;
 

--- a/src/driving/SnackTech.API/Properties/launchSettings.json
+++ b/src/driving/SnackTech.API/Properties/launchSettings.json
@@ -12,7 +12,7 @@
     },
     "https": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/src/tests/SnackTech.API.Tests/ControllersTests/ClientesControllerTests.cs
+++ b/src/tests/SnackTech.API.Tests/ControllersTests/ClientesControllerTests.cs
@@ -102,8 +102,9 @@ namespace SnackTech.API.Tests.ControllersTests
 
         [Fact]
         public async Task GetDefaultClientWithSuccess(){
+            var retornoCliente = new RetornoCliente{};
             clienteService.Setup(c => c.SelecionarClientePadrao())
-                            .ReturnsAsync(new Result<Guid>(Guid.NewGuid()));
+                            .ReturnsAsync(new Result<RetornoCliente>(retornoCliente));
 
             var resultado = await clientesController.GetDefaultClient();
 
@@ -112,8 +113,9 @@ namespace SnackTech.API.Tests.ControllersTests
 
         [Fact]
         public async Task GetDefaultClientWithBadRequest(){
+
             clienteService.Setup(c => c.SelecionarClientePadrao())
-                            .ReturnsAsync(new Result<Guid>("Erro de lógica",true));
+                            .ReturnsAsync(new Result<RetornoCliente>("Erro de lógica",true));
 
             var resultado = await clientesController.GetDefaultClient();
 

--- a/src/tests/SnackTech.API.Tests/ControllersTests/PedidosControllerTests.cs
+++ b/src/tests/SnackTech.API.Tests/ControllersTests/PedidosControllerTests.cs
@@ -26,7 +26,10 @@ namespace SnackTech.API.Tests.ControllersTests
             pedidoService.Setup(c => c.IniciarPedido(It.IsAny<string>()))
                             .ReturnsAsync(new Result<Guid>(Guid.NewGuid()));
 
-            var resultado = await pedidosController.IniciarPedido("1");
+            var iniciarPedido = new IniciarPedido{
+                Cpf = "1"
+            };
+            var resultado = await pedidosController.IniciarPedido(iniciarPedido);
 
             Assert.IsType<OkObjectResult>(resultado);
         }
@@ -37,7 +40,10 @@ namespace SnackTech.API.Tests.ControllersTests
             pedidoService.Setup(c => c.IniciarPedido(It.IsAny<string>()))
                             .ReturnsAsync(new Result<Guid>("Erro de lógica", true));
 
-            var resultado = await pedidosController.IniciarPedido("1");
+            var iniciarPedido = new IniciarPedido{
+                Cpf = "1"
+            };
+            var resultado = await pedidosController.IniciarPedido(iniciarPedido);
 
             var objectResult = Assert.IsType<BadRequestObjectResult>(resultado);
             var payload = Assert.IsType<ErrorResponse>(objectResult.Value);
@@ -51,8 +57,11 @@ namespace SnackTech.API.Tests.ControllersTests
             var cadastroCliente = new CadastroCliente();
             pedidoService.Setup(c => c.IniciarPedido(It.IsAny<string>()))
                             .ThrowsAsync(new Exception("Erro inesperado"));
-
-            var resultado = await pedidosController.IniciarPedido("1");
+            
+            var iniciarPedido = new IniciarPedido{
+                Cpf = "1"
+            };
+            var resultado = await pedidosController.IniciarPedido(iniciarPedido);
             var objectResult = Assert.IsType<ObjectResult>(resultado);
             var payload = Assert.IsType<ErrorResponse>(objectResult.Value);
 


### PR DESCRIPTION
Retornando um json da rota de cliente padrão
Retornando Bad Request caso já exista um cpf cadastrado como cliente na rota de post de cliente
Passando o cpf como parâmetro de rota no get de ultimo pedido do cliente
Altertando pedidos/atualizar para pedidos, usando o verto PUT
Alterando verbo de finalização de pagamento para PATCH ao invés de usar POST