### PR TITLE
Atualizar a Collection do Postman e padronizar nome do campo ID nos DTOs do lado da API

### DIFF
--- a/SnackTech.postman_collection.json
+++ b/SnackTech.postman_collection.json
@@ -10,7 +10,7 @@
 			"name": "Pedido",
 			"item": [
 				{
-					"name": "Pedido - Iniciar",
+					"name": "1. Pedido - Iniciar",
 					"request": {
 						"method": "POST",
 						"header": [],
@@ -39,13 +39,13 @@
 					"response": []
 				},
 				{
-					"name": "Pedido - Atualizar",
+					"name": "2. Pedido - Atualizar",
 					"request": {
 						"method": "PUT",
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n  \"identificacao\": \"8668f733-ab3d-4fb4-b644-d5aab840d5fe\",\r\n  \"pedidoItens\": [\r\n    // {\r\n    //   \"sequencial\": 3,\r\n    //   \"identificacaoProduto\": \"3f30c44a-e76a-47e7-8253-487cd9eaa4b6\",\r\n    //   \"quantidade\": 3,\r\n    //   \"observacao\": \"descrição 3\"\r\n    // },\r\n    {\r\n      \"sequencial\": 2,\r\n      \"identificacaoProduto\": \"3f30c44a-e76a-47e7-8253-487cd9eaa4b6\",\r\n      \"quantidade\": 1,\r\n      \"observacao\": \"descrição 2\"\r\n    },\r\n    {\r\n      \"sequencial\": 1,\r\n      \"identificacaoProduto\": \"3f30c44a-e76a-47e7-8253-487cd9eaa4b6\",\r\n      \"quantidade\": 1,\r\n      \"observacao\": \"descrição 1\"\r\n    }\r\n  ]\r\n}",
+							"raw": "{\r\n  \"identificacaoPedido\": \"df34566d-8b04-4de6-b396-96bd294e5a93\",\r\n  \"pedidoItens\": [\r\n    {\r\n      \"identificacaoProduto\": \"0c74c3ba-d33b-43d4-8aa1-fceeda0fed92\",\r\n      \"quantidade\": 1,\r\n      \"observacao\": \"\"\r\n    },\r\n    {\r\n      \"identificacaoProduto\": \"0c74c3ba-d33b-43d4-8aa1-fceeda0fed92\",\r\n      \"quantidade\": 2,\r\n      \"observacao\": \"descrição 2\"\r\n    }\r\n    // {\r\n    //   \"identificacaoProduto\": \"340ac3d2-f798-4dd1-9b7c-b8ad6ea891b0\",\r\n    //   \"quantidade\": 1,\r\n    //   \"observacao\": \"descrição 1\"\r\n    // }\r\n  ]\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -68,7 +68,7 @@
 					"response": []
 				},
 				{
-					"name": "Pedido - Finalizar para pagamento",
+					"name": "3. Pedido - Finalizar para pagamento",
 					"request": {
 						"method": "PATCH",
 						"header": [],
@@ -99,12 +99,21 @@
 					"response": []
 				},
 				{
-					"name": "Pedido - Pesquisar",
+					"name": "5. Pedido - Iniciar Preparação",
 					"request": {
-						"method": "GET",
+						"method": "PATCH",
 						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
 						"url": {
-							"raw": "http://localhost:8080/api/Pedidos/8668f733-ab3d-4fb4-b644-d5aab840d5fe",
+							"raw": "http://localhost:8080/api/Pedidos/iniciar-preparacao/df34566d-8b04-4de6-b396-96bd294e5a93",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -113,7 +122,91 @@
 							"path": [
 								"api",
 								"Pedidos",
-								"8668f733-ab3d-4fb4-b644-d5aab840d5fe"
+								"iniciar-preparacao",
+								"df34566d-8b04-4de6-b396-96bd294e5a93"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "6. Pedido - Concluir Preparação",
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8080/api/Pedidos/concluir-preparacao/df34566d-8b04-4de6-b396-96bd294e5a93",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"api",
+								"Pedidos",
+								"concluir-preparacao",
+								"df34566d-8b04-4de6-b396-96bd294e5a93"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "7. Pedido - Finalizar",
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8080/api/Pedidos/finalizar/df34566d-8b04-4de6-b396-96bd294e5a93",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"api",
+								"Pedidos",
+								"finalizar",
+								"df34566d-8b04-4de6-b396-96bd294e5a93"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Pedido - Pesquisar",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8080/api/Pedidos/df34566d-8b04-4de6-b396-96bd294e5a93",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"api",
+								"Pedidos",
+								"df34566d-8b04-4de6-b396-96bd294e5a93"
 							]
 						}
 					},
@@ -142,7 +235,7 @@
 					"response": []
 				},
 				{
-					"name": "Pedido - Aguardando Pagamento",
+					"name": "Pedido - Listar Aguardando Pagamento",
 					"request": {
 						"method": "GET",
 						"header": [],
@@ -161,6 +254,27 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Pedido - Listar Ativos",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8080/api/Pedidos/ativos",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"api",
+								"Pedidos",
+								"ativos"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},
@@ -174,7 +288,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "// {\r\n//   \"categoria\": 1,\r\n//   \"nome\": \"Lanche 2\",\r\n//   \"descricao\": \"vvvvvv\",\r\n//   \"valor\": 3\r\n// }\r\n\r\n{\r\n  \"categoria\": 1,\r\n  \"nome\": \"Lanche 1\",\r\n  \"descricao\": \"aaaa\",\r\n  \"valor\": 32\r\n}\r\n\r\n// {\r\n//   \"categoria\": 2,\r\n//   \"nome\": \"Acompanhamento 1\",\r\n//   \"descricao\": \"aaaaaaa\",\r\n//   \"valor\": 1\r\n// }",
+							"raw": "{\r\n  \"categoria\": 3,\r\n  \"nome\": \"Produto 3\",\r\n  \"descricao\": \"teste descrição\",\r\n  \"valor\": 30\r\n}\r\n\r\n// {\r\n//   \"categoria\": 1,\r\n//   \"nome\": \"Lanche 1\",\r\n//   \"descricao\": \"aaaa\",\r\n//   \"valor\": 32\r\n// }\r\n\r\n// {\r\n//   \"categoria\": 2,\r\n//   \"nome\": \"Acompanhamento 1\",\r\n//   \"descricao\": \"aaaaaaa\",\r\n//   \"valor\": 1\r\n// }",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -203,7 +317,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n  \"categoria\": 1,\r\n  \"nome\": \"Lanche 2 - Editado\",\r\n  \"descricao\": \"vvvvvv\",\r\n  \"valor\": 10\r\n}\r\n\r\n// {\r\n//   \"categoria\": 1,\r\n//   \"nome\": \"Lanche 1\",\r\n//   \"descricao\": \"aaaa\",\r\n//   \"valor\": 32\r\n// }\r\n\r\n// {\r\n//   \"categoria\": 2,\r\n//   \"nome\": \"Acompanhamento 1\",\r\n//   \"descricao\": \"aaaaaaa\",\r\n//   \"valor\": 1\r\n// }",
+							"raw": "{\r\n  \"categoria\": 3,\r\n  \"nome\": \"Produto 3 - Editado\",\r\n  \"descricao\": \"nova descrição\",\r\n  \"valor\": 10\r\n}\r\n\r\n// {\r\n//   \"categoria\": 1,\r\n//   \"nome\": \"Lanche 1\",\r\n//   \"descricao\": \"aaaa\",\r\n//   \"valor\": 32\r\n// }\r\n\r\n// {\r\n//   \"categoria\": 2,\r\n//   \"nome\": \"Acompanhamento 1\",\r\n//   \"descricao\": \"aaaaaaa\",\r\n//   \"valor\": 1\r\n// }",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -211,7 +325,7 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:8080/api/Produtos/3f30c44a-e76a-47e7-8253-487cd9eaa4b6",
+							"raw": "http://localhost:8080/api/Produtos/8b04b40e-b446-4585-bd9d-e826a2254848",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -220,7 +334,7 @@
 							"path": [
 								"api",
 								"Produtos",
-								"3f30c44a-e76a-47e7-8253-487cd9eaa4b6"
+								"8b04b40e-b446-4585-bd9d-e826a2254848"
 							]
 						}
 					},
@@ -233,7 +347,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n  \"categoria\": 1,\r\n  \"nome\": \"Lanche 2 - Editado\",\r\n  \"descricao\": \"vvvvvv\",\r\n  \"valor\": 10\r\n}\r\n\r\n// {\r\n//   \"categoria\": 1,\r\n//   \"nome\": \"Lanche 1\",\r\n//   \"descricao\": \"aaaa\",\r\n//   \"valor\": 32\r\n// }\r\n\r\n// {\r\n//   \"categoria\": 2,\r\n//   \"nome\": \"Acompanhamento 1\",\r\n//   \"descricao\": \"aaaaaaa\",\r\n//   \"valor\": 1\r\n// }",
+							"raw": "",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -241,7 +355,7 @@
 							}
 						},
 						"url": {
-							"raw": "http://localhost:8080/api/Produtos/f9e66763-345b-49a8-9582-8dcbece7a27e",
+							"raw": "http://localhost:8080/api/Produtos/8b04b40e-b446-4585-bd9d-e826a2254848",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -250,7 +364,7 @@
 							"path": [
 								"api",
 								"Produtos",
-								"f9e66763-345b-49a8-9582-8dcbece7a27e"
+								"8b04b40e-b446-4585-bd9d-e826a2254848"
 							]
 						}
 					},
@@ -289,7 +403,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n  \"nome\": \"Teste usuario\",\r\n  \"email\": \"adriano@aaaaa.com\",\r\n  \"cpf\": \"08742938473\"\r\n}\r\n",
+							"raw": "{\r\n  \"nome\": \"Teste usuario\",\r\n  \"email\": \"teste@aaaaa.com\",\r\n  \"cpf\": \"12345678909\"\r\n}\r\n",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -317,7 +431,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "http://localhost:8080/api/Clientes/00000000191",
+							"raw": "http://localhost:8080/api/Clientes/12345678909",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -326,7 +440,7 @@
 							"path": [
 								"api",
 								"Clientes",
-								"00000000191"
+								"12345678909"
 							]
 						}
 					},

--- a/src/common/SnackTech.Common/Dto/Api/ClienteDto.cs
+++ b/src/common/SnackTech.Common/Dto/Api/ClienteDto.cs
@@ -2,7 +2,7 @@ namespace SnackTech.Common.Dto.Api;
 
 public class ClienteDto
 {
-    public Guid Id { get; set; }
+    public Guid IdentificacaoCliente { get; set; }
     public string Nome { get; set; } = string.Empty;
     public string Email { get; set; } = string.Empty;
     public string Cpf { get; set; } = string.Empty;

--- a/src/common/SnackTech.Common/Dto/Api/PedidoAtualizacaoDto.cs
+++ b/src/common/SnackTech.Common/Dto/Api/PedidoAtualizacaoDto.cs
@@ -2,6 +2,6 @@ namespace SnackTech.Common.Dto.Api;
 
 public class PedidoAtualizacaoDto
 {
-    public string Identificacao { get; set; }
+    public string IdentificacaoPedido { get; set; }
     public IEnumerable<PedidoItemAtualizacaoDto> PedidoItens { get; set; }
 }

--- a/src/common/SnackTech.Common/Dto/Api/PedidoItemAtualizacaoDto.cs
+++ b/src/common/SnackTech.Common/Dto/Api/PedidoItemAtualizacaoDto.cs
@@ -2,8 +2,8 @@ namespace SnackTech.Common.Dto.Api;
 
 public class PedidoItemAtualizacaoDto
 {
-    //Informar o Id caso seja uma atualiza��o do item ou null para item novo no pedido
-    public string? Identificacao { get; set; }
+    //Informar o Id caso seja uma atualização do item ou null para item novo no pedido
+    public string? IdentificacaoItem { get; set; }
     public int Quantidade { get; set; }
     public string Observacao { get; set; }
     public string IdentificacaoProduto { get; set; }

--- a/src/common/SnackTech.Common/Dto/Api/PedidoItemRetornoDto.cs
+++ b/src/common/SnackTech.Common/Dto/Api/PedidoItemRetornoDto.cs
@@ -2,7 +2,7 @@ namespace SnackTech.Common.Dto.Api;
 
 public class PedidoItemRetornoDto
 {
-    public Guid Id { get; set; }
+    public Guid IdentificacaoItem { get; set; }
     public int Quantidade { get; set; }
     public decimal Valor { get; set; }
     public string Observacao { get; set; }

--- a/src/common/SnackTech.Common/Dto/Api/PedidoRetornoDto.cs
+++ b/src/common/SnackTech.Common/Dto/Api/PedidoRetornoDto.cs
@@ -2,7 +2,7 @@ namespace SnackTech.Common.Dto.Api;
 
 public class PedidoRetornoDto
 {
-    public Guid Id { get; set; }
+    public Guid IdentificacaoPedido { get; set; }
     public DateTime DataCriacao { get; set; }
     public int Status { get; set; }
     public ClienteDto Cliente { get; set; }

--- a/src/common/SnackTech.Common/Dto/Api/ProdutoDto.cs
+++ b/src/common/SnackTech.Common/Dto/Api/ProdutoDto.cs
@@ -2,7 +2,7 @@ namespace SnackTech.Common.Dto.Api
 {
     public class ProdutoDto
     {
-        public Guid Id { get; set; }
+        public Guid IdentificacaoProduto { get; set; }
         public int Categoria { get; set; }
         public string Nome { get; set; } = string.Empty;
         public string Descricao { get; set; } = string.Empty;

--- a/src/core/SnackTech.Core/Domain/Types/GuidValido.cs
+++ b/src/core/SnackTech.Core/Domain/Types/GuidValido.cs
@@ -47,7 +47,7 @@ internal struct GuidValido : IEquatable<GuidValido>
         }
         else
         {
-            throw new ArgumentException($"A Identifica��o informada {guidValue} n�o � um Guid v�lido.");
+            throw new ArgumentException($"A Identificação informada {guidValue} não é um Guid válido.");
         }
     }
 

--- a/src/core/SnackTech.Core/Gateways/ClienteGateway.cs
+++ b/src/core/SnackTech.Core/Gateways/ClienteGateway.cs
@@ -28,7 +28,7 @@ internal class ClienteGateway(IClienteDataSource dataSource)
 
     internal async Task<Cliente?> ProcurarClientePorEmail(EmailValido emailCliente)
     {
-        var clienteDto = await dataSource.PesquisarPorCpfAsync(emailCliente);
+        var clienteDto = await dataSource.PesquisarPorEmailAsync(emailCliente);
 
         if (clienteDto == null || clienteDto.Id == Guid.Empty)
         {

--- a/src/core/SnackTech.Core/Presenters/ClientePresenter.cs
+++ b/src/core/SnackTech.Core/Presenters/ClientePresenter.cs
@@ -15,7 +15,7 @@ internal class ClientePresenter
     {
         return new ClienteDto
         {
-            Id = cliente.Id,
+            IdentificacaoCliente = cliente.Id,
             Nome = cliente.Nome.Valor,
             Email = cliente.Email.Valor,
             Cpf = cliente.Cpf.Valor

--- a/src/core/SnackTech.Core/Presenters/PedidoPresenter.cs
+++ b/src/core/SnackTech.Core/Presenters/PedidoPresenter.cs
@@ -49,7 +49,7 @@ internal class PedidoPresenter
     {
         return new PedidoRetornoDto
         {
-            Id = pedido.Id,
+            IdentificacaoPedido = pedido.Id,
             DataCriacao = pedido.DataCriacao.Valor,
             Status = pedido.Status.Valor,
             Cliente = ClientePresenter.ConverterParaDto(pedido.Cliente),
@@ -61,7 +61,7 @@ internal class PedidoPresenter
     {
         return new PedidoItemRetornoDto
         {
-            Id = pedidoItem.Id,
+            IdentificacaoItem = pedidoItem.Id,
             Quantidade = pedidoItem.Quantidade.Valor,
             Observacao = pedidoItem.Observacao,
             Valor = pedidoItem.Valor(),

--- a/src/core/SnackTech.Core/Presenters/ProdutoPresenter.cs
+++ b/src/core/SnackTech.Core/Presenters/ProdutoPresenter.cs
@@ -19,7 +19,7 @@ internal static class ProdutoPresenter
     {
         return new ProdutoDto
         {
-            Id = produto.Id,
+            IdentificacaoProduto = produto.Id,
             Categoria = produto.Categoria,
             Descricao = produto.Descricao,
             Nome = produto.Nome,

--- a/src/core/SnackTech.Core/UseCases/PedidoUseCase.cs
+++ b/src/core/SnackTech.Core/UseCases/PedidoUseCase.cs
@@ -64,7 +64,7 @@ internal static class PedidoUseCase
             }
 
             var ultimosPedidos = await pedidoGateway.PesquisarPedidosPorCliente(cliente.Id);
-            var ultimoPedido = ultimosPedidos.OrderBy(p => p.DataCriacao).LastOrDefault();
+            var ultimoPedido = ultimosPedidos.OrderBy(p => p.DataCriacao.Valor).LastOrDefault();
 
             var retorno = ultimoPedido is null ?
                                 GeralPresenter.ApresentarResultadoErroLogico<PedidoRetornoDto>($"Não foi possível encontrar um pedido para o cliente com CPF {cpfCliente}.") :
@@ -203,7 +203,7 @@ internal static class PedidoUseCase
             //A ordem dos status no Enum já representa a sequencia desejada para os status.
             var pedidosOrdenados =  pedidos
                 .OrderByDescending(p => (int)p.Status)
-                .ThenByDescending(p => p.DataCriacao)
+                .ThenByDescending(p => p.DataCriacao.Valor)
                 .ToList();
             var retorno = PedidoPresenter.ApresentarResultadoPedido(pedidos);
 

--- a/src/core/SnackTech.Core/UseCases/PedidoUseCase.cs
+++ b/src/core/SnackTech.Core/UseCases/PedidoUseCase.cs
@@ -129,17 +129,17 @@ internal static class PedidoUseCase
     {
         try
         {
-            var pedido = await pedidoGateway.PesquisarPorIdentificacao(pedidoAtualizado.Identificacao);
+            var pedido = await pedidoGateway.PesquisarPorIdentificacao(pedidoAtualizado.IdentificacaoPedido);
 
             if(pedido is null)
             {
-                return GeralPresenter.ApresentarResultadoErroLogico<PedidoRetornoDto>($"Não foi possível encontrar um pedido com identificação {pedidoAtualizado.Identificacao}.");
+                return GeralPresenter.ApresentarResultadoErroLogico<PedidoRetornoDto>($"Não foi possível encontrar um pedido com identificação {pedidoAtualizado.IdentificacaoPedido}.");
             }
 
             //itens atualizados com GUID e que não existem no pedido persistido
             var itensNovosComIds = pedidoAtualizado.PedidoItens
-                .Where(item => item.Identificacao != null)
-                .Where(itemAtualizado => !pedido.Itens.Any(item => item.Id == itemAtualizado.Identificacao))
+                .Where(item => item.IdentificacaoItem != null)
+                .Where(itemAtualizado => !pedido.Itens.Any(item => item.Id == itemAtualizado.IdentificacaoItem))
                 .ToList();
 
             if (itensNovosComIds.Count > 0)
@@ -148,7 +148,7 @@ internal static class PedidoUseCase
             }
 
             //remover itens do pedido que estejam ausentes no pedido atualizado
-            pedido.Itens.RemoveAll(itemPedido => !pedidoAtualizado.PedidoItens.Any(itemAtualizado => itemAtualizado.Identificacao == itemPedido.Id));
+            pedido.Itens.RemoveAll(itemPedido => !pedidoAtualizado.PedidoItens.Any(itemAtualizado => itemAtualizado.IdentificacaoItem == itemPedido.Id));
 
             //validar itens do pedido atualizado
             List<PedidoItem> itensValidados = await validarItensPedido(pedidoAtualizado.PedidoItens, produtoGateway);
@@ -160,7 +160,7 @@ internal static class PedidoUseCase
 
             var retorno = foiAtualizado ?
                 PedidoPresenter.ApresentarResultadoPedido(pedido) :
-                GeralPresenter.ApresentarResultadoErroLogico<PedidoRetornoDto>($"Não foi possível atualizar os itens do pedido com identificação {pedidoAtualizado.Identificacao}.");
+                GeralPresenter.ApresentarResultadoErroLogico<PedidoRetornoDto>($"Não foi possível atualizar os itens do pedido com identificação {pedidoAtualizado.IdentificacaoPedido}.");
 
             return retorno;
         }
@@ -183,7 +183,7 @@ internal static class PedidoUseCase
                 throw new ArgumentException($"Não existe produto com identificação {item.IdentificacaoProduto}.");
             }
 
-            Guid identificacaoItem = item.Identificacao is null || item.Identificacao == string.Empty ? Guid.NewGuid() : new GuidValido(item.Identificacao);
+            Guid identificacaoItem = item.IdentificacaoItem is null || item.IdentificacaoItem == string.Empty ? Guid.NewGuid() : new GuidValido(item.IdentificacaoItem);
             itensValidados.Add(new PedidoItem(identificacaoItem, produto, item.Quantidade, item.Observacao));
         }
 

--- a/src/infra.web-api/SnackTech.Driver.API/Controllers/ClientesController.cs
+++ b/src/infra.web-api/SnackTech.Driver.API/Controllers/ClientesController.cs
@@ -18,7 +18,7 @@ namespace SnackTech.Driver.API.Controllers
         /// Cria um nova cliente no sistema.
         /// </remarks>
         /// <param name="cadastroCliente">Os dados do cliente a ser criado.</param>
-        /// <returns>Um <see cref="IActionResult"/> representando o resultado da opera��o.</returns>
+        /// <returns>Um <see cref="IActionResult"/> representando o resultado da operação.</returns>
         [HttpPost]
         [Consumes(MediaTypeNames.Application.Json)]
         [ProducesResponseType<ClienteDto>(StatusCodes.Status200OK)]
@@ -32,7 +32,7 @@ namespace SnackTech.Driver.API.Controllers
         /// Retorna o cliente com o CPF informado.
         /// </summary>
         /// <remarks>
-        /// Retorna as informa��es de um cliente baseado no CPF fornecido.
+        /// Retorna as informações de um cliente baseado no CPF fornecido.
         /// </remarks>
         /// <param name="cpf">O CPF do cliente a ser pesquisado.</param>
         /// <returns>Um <see cref="IActionResult"/> contendo o cliente encontrado ou um erro correspondente.</returns>
@@ -49,7 +49,7 @@ namespace SnackTech.Driver.API.Controllers
         /// Retorna o cliente padrao.
         /// </summary>
         /// <remarks>
-        /// Retorna as informa��es do cliente padr?o do sistema.
+        /// Retorna as informações do cliente padrão do sistema.
         /// </remarks>
         /// <returns>Um <see cref="IActionResult"/> contendo o cliente encontrado ou um erro correspondente.</returns>
         [HttpGet]

--- a/src/infra.web-api/SnackTech.Driver.API/Controllers/ProdutosController.cs
+++ b/src/infra.web-api/SnackTech.Driver.API/Controllers/ProdutosController.cs
@@ -32,7 +32,7 @@ namespace SnackTech.Driver.API.Controllers
         /// </summary>
         /// <param name="identificacao">O guid do produto a ser editado.</param>
         /// <param name="produtoEditado">Os novos dados do produto.</param>
-        /// <returns>Um <see cref="IActionResult"/> indicando o sucesso ou falha da opera��o.</returns>
+        /// <returns>Um <see cref="IActionResult"/> indicando o sucesso ou falha da operação.</returns>
         [HttpPut]
         [Consumes(MediaTypeNames.Application.Json)]
         [ProducesResponseType(StatusCodes.Status200OK)]
@@ -47,7 +47,7 @@ namespace SnackTech.Driver.API.Controllers
         /// Remove um produto existente no sistema.
         /// </summary>
         /// <param name="identificacao">O guid do produto a ser removido.</param>
-        /// <returns>Um <see cref="IActionResult"/> indicando o sucesso ou falha da opera��o.</returns>
+        /// <returns>Um <see cref="IActionResult"/> indicando o sucesso ou falha da operação.</returns>
         [HttpDelete]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType<ErrorResponse>(StatusCodes.Status400BadRequest)]

--- a/src/tests/SnackTech.Core.Tests/Gateways/ClienteGatewayTest.cs
+++ b/src/tests/SnackTech.Core.Tests/Gateways/ClienteGatewayTest.cs
@@ -109,7 +109,7 @@ namespace SnackTech.Core.Tests.Gateways
         }
 
         [Fact]
-        public async Task ProcurarClientePorEmail_DeveChamarPesquisarPorCpfAsync_DoDataSource()
+        public async Task ProcurarClientePorEmail_DeveChamarPesquisarPorEmailAsync_DoDataSource()
         {
             // Arrange
             var email = new EmailValido("email@email.com");
@@ -118,16 +118,16 @@ namespace SnackTech.Core.Tests.Gateways
             await _clienteGateway.ProcurarClientePorEmail(email);
         
             // Assert
-            Mock.Assert(() => _dataSource.PesquisarPorCpfAsync(Arg.IsAny<string>()), Occurs.Once());
+            Mock.Assert(() => _dataSource.PesquisarPorEmailAsync(Arg.IsAny<string>()), Occurs.Once());
         }
         
         [Fact]
-        public async Task ProcurarClientePorEmail_DeveRetornarCliente_SePesquisarPorCpfAsync_DoDataSource_RetornarClienteDto()
+        public async Task ProcurarClientePorEmail_DeveRetornarCliente_SePesquisarPorEmailAsync_DoDataSource_RetornarClienteDto()
         {
             // Arrange
             var email = new EmailValido("email@email.com");
             var clienteDto = new ClienteDto { Id = Guid.NewGuid(), Nome = "nome", Email = "email@email.com", Cpf = "00000000191" };
-            Mock.Arrange(() => _dataSource.PesquisarPorCpfAsync(Arg.IsAny<string>())).ReturnsAsync(clienteDto);
+            Mock.Arrange(() => _dataSource.PesquisarPorEmailAsync(Arg.IsAny<string>())).ReturnsAsync(clienteDto);
         
             // Act
             var cliente = await _clienteGateway.ProcurarClientePorEmail(email);

--- a/src/tests/SnackTech.Core.Tests/Presenters/ClientePresenterTest.cs
+++ b/src/tests/SnackTech.Core.Tests/Presenters/ClientePresenterTest.cs
@@ -20,7 +20,7 @@ public class ClientePresenterTest
     
         // Assert
         clienteDto.Should().NotBeNull();
-        clienteDto.Id.Should().Be(_clienteExemplo.Id.Valor);
+        clienteDto.IdentificacaoCliente.Should().Be(_clienteExemplo.Id.Valor);
         clienteDto.Nome.Should().Be(_clienteExemplo.Nome.Valor);
         clienteDto.Email.Should().Be(_clienteExemplo.Email.Valor);
         clienteDto.Cpf.Should().Be(_clienteExemplo.Cpf.Valor);
@@ -35,7 +35,7 @@ public class ClientePresenterTest
         // Assert
         resultado.Should().NotBeNull();
         resultado.Dados.Should().NotBeNull();
-        resultado.Dados.Id.Should().Be(_clienteExemplo.Id.Valor);
+        resultado.Dados.IdentificacaoCliente.Should().Be(_clienteExemplo.Id.Valor);
         resultado.Dados.Nome.Should().Be(_clienteExemplo.Nome.Valor);
         resultado.Dados.Email.Should().Be(_clienteExemplo.Email.Valor);
         resultado.Dados.Cpf.Should().Be(_clienteExemplo.Cpf.Valor);

--- a/src/tests/SnackTech.Core.Tests/Presenters/ProdutoPresenterTest.cs
+++ b/src/tests/SnackTech.Core.Tests/Presenters/ProdutoPresenterTest.cs
@@ -23,7 +23,7 @@ public class ProdutoPresenterTest
     
         // Assert
         produtoDto.Should().NotBeNull();
-        produtoDto.Id.Should().Be(_produtoExemplo.Id.Valor);
+        produtoDto.IdentificacaoProduto.Should().Be(_produtoExemplo.Id.Valor);
         produtoDto.Categoria.Should().Be(_produtoExemplo.Categoria.Valor);
         produtoDto.Descricao.Should().Be(_produtoExemplo.Descricao);
         produtoDto.Nome.Should().Be(_produtoExemplo.Nome.Valor);
@@ -39,7 +39,7 @@ public class ProdutoPresenterTest
         // Assert
         resultado.Should().NotBeNull();
         resultado.Dados.Should().NotBeNull();
-        resultado.Dados.Id.Should().Be(_produtoExemplo.Id.Valor);
+        resultado.Dados.IdentificacaoProduto.Should().Be(_produtoExemplo.Id.Valor);
         resultado.Dados.Categoria.Should().Be(_produtoExemplo.Categoria.Valor);
         resultado.Dados.Descricao.Should().Be(_produtoExemplo.Descricao);
         resultado.Dados.Nome.Should().Be(_produtoExemplo.Nome.Valor);


### PR DESCRIPTION
* Atualizei a collection do Postman incluindo os novos endpoints
* Considerando um apontamento do Rafael sobre confundir o id do produto com o id do PedidoItem, alterei o nome dos campos id dos DTOs do lado da API. Agora todos estão no padrão Identificacao<Entidade>. Deixando explicito a quem eles se referem. 
* Identifiquei e corrigi um bug relacionado a ordenação dos pedidos. 